### PR TITLE
Correct IoT Class of integration

### DIFF
--- a/custom_components/flashforge_adventurer_3/manifest.json
+++ b/custom_components/flashforge_adventurer_3/manifest.json
@@ -5,7 +5,7 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/modrzew/hass-flashforge-adventurer-3/",
-  "iot_class": "cloud_polling",
+  "iot_class": "local_polling",
   "issue_tracker": "https://github.com/modrzew/hass-flashforge-adventurer-3/issues",
   "requirements": [],
   "version": "1.0.0"


### PR DESCRIPTION
Since integration doesn't use any cloud services to communicate with the 3D printer and whole communication is done localy, it should have Local Polling IoT Class.

Docs: https://developers.home-assistant.io/docs/creating_integration_manifest/#iot-class